### PR TITLE
Fix missing participants

### DIFF
--- a/src/participants.js
+++ b/src/participants.js
@@ -22,9 +22,9 @@ export const calculateNumAttended = participants => participants.reduce((m, v) =
 
 export const calculateFinalizeMaps = (participants, overrideMissingValue) => {
   if (!(overrideMissingValue === undefined ||
-    overrideMissingValue === 0 ||
-    overrideMissingValue === 1)) {
-    throw new Error(`Invalid overrideMissingValue, expected undefined, 0 or 1 , got ${overrideMissingValue}`)
+    overrideMissingValue === PARTICIPANT_STATUS.SHOWED_UP ||
+    overrideMissingValue === PARTICIPANT_STATUS.REGISTERED)) {
+    throw new Error(`Invalid overrideMissingValue, expected undefined, SHOWED_UP or REGISTERED , got ${overrideMissingValue}`)
   }
 
   // sort participants array
@@ -38,14 +38,8 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue) => {
         throw new Error(`Participant ${i} is missing`)
       }
 
-      let status
-      if (overrideMissingValue === 0)
-      { status = PARTICIPANT_STATUS.REGISTERED }
-      else
-      { status = PARTICIPANT_STATUS.SHOWED_UP }
-
       participants.splice(i, 0, {
-        status,
+        overrideMissingValue,
         index: i,
         user: {
           address: '0x0000000000000000000000000000000000000000'

--- a/src/participants.js
+++ b/src/participants.js
@@ -32,15 +32,14 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue = false
   // check for missing participants
   for(let i = 0; participants.length > i; ) {
     const currentIndex = participants[i].index
-    if(currentIndex !== i + 1) {
-
+    if(currentIndex !== i) {
       if(!overrideMissingValue) {
-        throw new Error(`Participant ${i + 1} is missing`)
+        throw new Error(`Participant ${i} is missing`)
       }
 
-      list.splice(i, 0, {
+      participants.splice(i, 0, {
         status: PARTICIPANT_STATUS.REGISTERED,
-        index: i + 1,
+        index: i,
         user: {
           address: '0x0000000000000000000000000000000000000000'
         },
@@ -69,8 +68,8 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue = false
         throw new Error(`Unexpected participant status: ${participants[i].status}`)
     }
   }
+ 
   maps.push(currentMap)
-
   return maps.map(m => m.toString(10))
 }
 

--- a/src/participants.js
+++ b/src/participants.js
@@ -20,10 +20,10 @@ export const calculateNumAttended = participants => participants.reduce((m, v) =
   return m + (attended ? 1 : 0)
 }, 0)
 
-export const calculateFinalizeMaps = (participants, overrideMissingValue = false) => {
+export const calculateFinalizeMaps = (participants, overrideMissingValue) => {
 
-  if(!(overrideMissingValue === true || overrideMissingValue === false)) {
-    throw new Error(`Invalid overrideMissingValue, expected true or false, got ${overrideMissingValue}`)
+  if(!(overrideMissingValue === undefined || overrideMissingValue === 0 || overrideMissingValue === 1)) {
+    throw new Error(`Invalid overrideMissingValue, expected undefined, 0 or 1 , got ${overrideMissingValue}`)
   }
 
   // sort participants array
@@ -33,12 +33,12 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue = false
   for(let i = 0; participants.length > i; ) {
     const currentIndex = participants[i].index
     if(currentIndex !== i) {
-      if(!overrideMissingValue) {
+      if(overrideMissingValue === undefined) {
         throw new Error(`Participant ${i} is missing`)
       }
 
       participants.splice(i, 0, {
-        status: PARTICIPANT_STATUS.REGISTERED,
+        status: overrideMissingValue === 0 ? PARTICIPANT_STATUS.REGISTERED : PARTICIPANT_STATUS.SHOWED_UP,
         index: i,
         user: {
           address: '0x0000000000000000000000000000000000000000'

--- a/src/participants.js
+++ b/src/participants.js
@@ -21,8 +21,9 @@ export const calculateNumAttended = participants => participants.reduce((m, v) =
 }, 0)
 
 export const calculateFinalizeMaps = (participants, overrideMissingValue) => {
-
-  if(!(overrideMissingValue === undefined || overrideMissingValue === 0 || overrideMissingValue === 1)) {
+  if (!(overrideMissingValue === undefined ||
+    overrideMissingValue === 0 ||
+    overrideMissingValue === 1)) {
     throw new Error(`Invalid overrideMissingValue, expected undefined, 0 or 1 , got ${overrideMissingValue}`)
   }
 
@@ -30,23 +31,28 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue) => {
   participants.sort((a, b) => (a.index < b.index ? -1 : 1))
 
   // check for missing participants
-  for(let i = 0; participants.length > i; ) {
+  for (let i = 0; participants.length > i;) {
     const currentIndex = participants[i].index
-    if(currentIndex !== i) {
-      if(overrideMissingValue === undefined) {
+    if (currentIndex !== i) {
+      if (overrideMissingValue === undefined) {
         throw new Error(`Participant ${i} is missing`)
       }
 
+      let status
+      if (overrideMissingValue === 0)
+      { status = PARTICIPANT_STATUS.REGISTERED }
+      else
+      { status = PARTICIPANT_STATUS.SHOWED_UP }
+
       participants.splice(i, 0, {
-        status: overrideMissingValue === 0 ? PARTICIPANT_STATUS.REGISTERED : PARTICIPANT_STATUS.SHOWED_UP,
+        status,
         index: i,
         user: {
           address: '0x0000000000000000000000000000000000000000'
         },
       })
-
     } else {
-      i++
+      i += 1
     }
   }
 
@@ -68,7 +74,7 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue) => {
         throw new Error(`Unexpected participant status: ${participants[i].status}`)
     }
   }
- 
+
   maps.push(currentMap)
   return maps.map(m => m.toString(10))
 }

--- a/src/participants.js
+++ b/src/participants.js
@@ -41,7 +41,9 @@ export const calculateFinalizeMaps = (participants, overrideMissingValue = false
       list.splice(i, 0, {
         status: PARTICIPANT_STATUS.REGISTERED,
         index: i + 1,
-        address: '0x0000000000000000000000000000000000000000',
+        user: {
+          address: '0x0000000000000000000000000000000000000000'
+        },
       })
 
     } else {

--- a/src/participants.js
+++ b/src/participants.js
@@ -20,9 +20,34 @@ export const calculateNumAttended = participants => participants.reduce((m, v) =
   return m + (attended ? 1 : 0)
 }, 0)
 
-export const calculateFinalizeMaps = participants => {
+export const calculateFinalizeMaps = (participants, overrideMissingValue = false) => {
+
+  if(!(overrideMissingValue === true || overrideMissingValue === false)) {
+    throw new Error(`Invalid overrideMissingValue, expected true or false, got ${overrideMissingValue}`)
+  }
+
   // sort participants array
   participants.sort((a, b) => (a.index < b.index ? -1 : 1))
+
+  // check for missing participants
+  for(let i = 0; participants.length > i; ) {
+    const currentIndex = participants[i].index
+    if(currentIndex !== i + 1) {
+
+      if(!overrideMissingValue) {
+        throw new Error(`Participant ${i + 1} is missing`)
+      }
+
+      list.splice(i, 0, {
+        status: PARTICIPANT_STATUS.REGISTERED,
+        index: i + 1,
+        address: '0x0000000000000000000000000000000000000000',
+      })
+
+    } else {
+      i++
+    }
+  }
 
   const maps = []
   let currentMap = toBN(0)

--- a/src/participants.test.js
+++ b/src/participants.test.js
@@ -211,6 +211,30 @@ describe('.calculateFinalizeMaps', () => {
 
     expect(calculateFinalizeMaps(ps)).toEqual(maps)
   })
+
+  it.only('p5 is missing, override', () => {
+
+    // We set #6 to SHOWED_UP and remove #5 from the list
+    const maps = [
+      toBN(0).bincn(6).toString(10),
+      toBN(0).toString(10),
+    ]
+
+    ps.forEach(p => {
+      switch (p.index) {
+        case 6:
+          p.status = PARTICIPANT_STATUS.SHOWED_UP
+          break
+        default:
+          break
+      }
+    })
+
+    ps.sort((a, b) => (a.index < b.index ? -1 : 1))
+    ps.splice(5, 1)
+
+    expect(calculateFinalizeMaps(ps, true)).toEqual(maps)
+  })
 })
 
 

--- a/src/participants.test.js
+++ b/src/participants.test.js
@@ -213,7 +213,6 @@ describe('.calculateFinalizeMaps', () => {
   })
 
   it('p5 is missing, override REGISTERED', () => {
-
     // We set #6 to SHOWED_UP and remove #5 from the list
     const maps = [
       toBN(0).bincn(6).toString(10),
@@ -237,7 +236,6 @@ describe('.calculateFinalizeMaps', () => {
   })
 
   it('p5 is missing, override SHOWED_UP', () => {
-
     // We set #6 to SHOWED_UP and remove #5 from the list
     const maps = [
       toBN(0).bincn(6).bincn(5).toString(10),
@@ -261,13 +259,6 @@ describe('.calculateFinalizeMaps', () => {
   })
 
   it('p5 is missing, override default value', () => {
-
-    // We set #6 to SHOWED_UP and remove #5 from the list
-    const maps = [
-      toBN(0).bincn(6).bincn(5).toString(10),
-      toBN(0).toString(10),
-    ]
-
     ps.forEach(p => {
       switch (p.index) {
         case 6:
@@ -287,7 +278,6 @@ describe('.calculateFinalizeMaps', () => {
   it('override invalid value', () => {
     expect(() => calculateFinalizeMaps(ps, 123)).toThrow()
   })
-
 })
 
 

--- a/src/participants.test.js
+++ b/src/participants.test.js
@@ -212,7 +212,7 @@ describe('.calculateFinalizeMaps', () => {
     expect(calculateFinalizeMaps(ps)).toEqual(maps)
   })
 
-  it.only('p5 is missing, override', () => {
+  it('p5 is missing, override REGISTERED', () => {
 
     // We set #6 to SHOWED_UP and remove #5 from the list
     const maps = [
@@ -233,8 +233,61 @@ describe('.calculateFinalizeMaps', () => {
     ps.sort((a, b) => (a.index < b.index ? -1 : 1))
     ps.splice(5, 1)
 
-    expect(calculateFinalizeMaps(ps, true)).toEqual(maps)
+    expect(calculateFinalizeMaps(ps, 0)).toEqual(maps)
   })
+
+  it('p5 is missing, override SHOWED_UP', () => {
+
+    // We set #6 to SHOWED_UP and remove #5 from the list
+    const maps = [
+      toBN(0).bincn(6).bincn(5).toString(10),
+      toBN(0).toString(10),
+    ]
+
+    ps.forEach(p => {
+      switch (p.index) {
+        case 6:
+          p.status = PARTICIPANT_STATUS.SHOWED_UP
+          break
+        default:
+          break
+      }
+    })
+
+    ps.sort((a, b) => (a.index < b.index ? -1 : 1))
+    ps.splice(5, 1)
+
+    expect(calculateFinalizeMaps(ps, 1)).toEqual(maps)
+  })
+
+  it('p5 is missing, override default value', () => {
+
+    // We set #6 to SHOWED_UP and remove #5 from the list
+    const maps = [
+      toBN(0).bincn(6).bincn(5).toString(10),
+      toBN(0).toString(10),
+    ]
+
+    ps.forEach(p => {
+      switch (p.index) {
+        case 6:
+          p.status = PARTICIPANT_STATUS.SHOWED_UP
+          break
+        default:
+          break
+      }
+    })
+
+    ps.sort((a, b) => (a.index < b.index ? -1 : 1))
+    ps.splice(5, 1)
+
+    expect(() => calculateFinalizeMaps(ps)).toThrow()
+  })
+
+  it('override invalid value', () => {
+    expect(() => calculateFinalizeMaps(ps, 123)).toThrow()
+  })
+
 })
 
 

--- a/src/participants.test.js
+++ b/src/participants.test.js
@@ -232,7 +232,7 @@ describe('.calculateFinalizeMaps', () => {
     ps.sort((a, b) => (a.index < b.index ? -1 : 1))
     ps.splice(5, 1)
 
-    expect(calculateFinalizeMaps(ps, 0)).toEqual(maps)
+    expect(calculateFinalizeMaps(ps, PARTICIPANT_STATUS.REGISTERED)).toEqual(maps)
   })
 
   it('p5 is missing, override SHOWED_UP', () => {
@@ -255,7 +255,7 @@ describe('.calculateFinalizeMaps', () => {
     ps.sort((a, b) => (a.index < b.index ? -1 : 1))
     ps.splice(5, 1)
 
-    expect(calculateFinalizeMaps(ps, 1)).toEqual(maps)
+    expect(calculateFinalizeMaps(ps, PARTICIPANT_STATUS.SHOWED_UP)).toEqual(maps)
   })
 
   it('p5 is missing, override default value', () => {


### PR DESCRIPTION
## Fix missing participants
Adds checks for missing participants when calling calculating finalize maps. 

The method `calculateFinalizeMaps` has a new parameter `overrideMissingValue` which defaults to `false`. 

- If  `overrideMissingValue == false` the method throws an error when it detects a missing participant in the `participants` array.
- If  `overrideMissingValue == true` the method inserts a dummy participant with `status = PARTICIPANT_STATUS.REGISTERED` when it detects a missing participant


